### PR TITLE
jacob/BMD-66/confirmed-rdns

### DIFF
--- a/app/Ptr/DnsRecordService.php
+++ b/app/Ptr/DnsRecordService.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Packages\Rdns\App\Ptr;
+
+class DnsRecordService {
+  
+  /**
+   * @param string $domain
+   * 
+   * @return array 
+   */
+  public function get($domain){
+    return dns_get_record($domain, DNS_A + DNS_AAAA);    
+  }
+}

--- a/app/Ptr/DnsRecordService.php
+++ b/app/Ptr/DnsRecordService.php
@@ -9,7 +9,7 @@ class DnsRecordService {
    * 
    * @return array 
    */
-  public function get($domain){
+  public function getARecords ($domain) {
     return dns_get_record($domain, DNS_A + DNS_AAAA);    
   }
 }

--- a/app/Ptr/DnsRecordService.php
+++ b/app/Ptr/DnsRecordService.php
@@ -9,7 +9,7 @@ class DnsRecordService {
    * 
    * @return array 
    */
-  public function getARecords ($domain) {
+  public function getARecords ($domain): array {
     return dns_get_record($domain, DNS_A + DNS_AAAA);    
   }
 }

--- a/app/Ptr/PtrControllerTest.php
+++ b/app/Ptr/PtrControllerTest.php
@@ -158,12 +158,13 @@ class PtrControllerTest extends RdnsTestCase {
     });
   }
 
-  public function testInvalidPtrIpOnCreate(){
+  public function testPtrNotAssociatedWithIpOnCreate(){
     $this->asAdminWithPermissions(static::PERMISSIONS, function () {
       $this->mockDns('test_create', '1.1.1.3', 1);
       $ip = "9.9.9.9";
       $this->tryCreate(['ip' => $ip]);
       $this->assertResponseStatus(409);
+      $this->assertMessageContains('Invalid IP, IP is not associated with Ptr');
     });
   }
 

--- a/app/Ptr/PtrControllerTest.php
+++ b/app/Ptr/PtrControllerTest.php
@@ -6,7 +6,7 @@ use App\Entity\Entity;
 use App\Ip\IpAddressRangeContract;
 use App\Ip\IpAddressV4;
 use App\Server\Port\ServerPortWithEntitiesTestNetwork;
-use Illuminate\Http\JsonResponse;
+use Illuminate\Foundation\Testing\TestResponse;
 use Packages\Rdns\App\RdnsTestCase;
 
 class PtrControllerTest extends RdnsTestCase {
@@ -164,11 +164,11 @@ class PtrControllerTest extends RdnsTestCase {
       $ip = "9.9.9.9";
       $this->tryCreate(['ip' => $ip]);
       $this->assertResponseStatus(409);
-      $this->assertMessageContains('Invalid IP, IP is not associated with Ptr');
+      $this->assertMessageContains("Invalid PTR, Please ensure that test_create has an A or AAAA DNS record to 9.9.9.9");
     });
   }
 
-  protected function tryCreate(array $data = []): JsonResponse {
+  protected function tryCreate(array $data = []): TestResponse {
     return $this->post($this->url(), $data + ['ptr' => 'test_create']);
   }
 
@@ -180,7 +180,7 @@ class PtrControllerTest extends RdnsTestCase {
     return (string) $this->ipRange->end();
   }
 
-  protected function canCreateInsideEntityRange(): JsonResponse {
+  protected function canCreateInsideEntityRange(): TestResponse {
     $this->mockDns('test_create', '1.1.1.3', 1);
     $this->expectsEvents(Events\PtrCreated::class);
 
@@ -192,7 +192,7 @@ class PtrControllerTest extends RdnsTestCase {
     return $result;
   }
 
-  protected function canCreateOutsideEntityRange(): JsonResponse {
+  protected function canCreateOutsideEntityRange(): TestResponse {
     $this->mockDns('test_create', '5.5.5.5', 1);
     $this->expectsEvents(Events\PtrCreated::class);
 
@@ -230,20 +230,6 @@ class PtrControllerTest extends RdnsTestCase {
     ]);
   }
 
-  private function dontSeeInternalPTR(): void {
-    $this->dontSeeJson([
-      'ptr' => 'test_int_ptr_name',
-      'ip' => $this->startEntityRange(),
-    ]);
-  }
-
-  private function dontSeeExternalPTR(): void {
-    $this->dontSeeJson([
-      'ptr' => 'test_ext_ptr_name',
-      'ip' => '8.8.8.8',
-    ]);
-  }
-
   protected function canReadOutsideEntityRange(): void {
     $this->get($this->url());
     $this->assertResponseOk();
@@ -255,38 +241,38 @@ class PtrControllerTest extends RdnsTestCase {
   }
 
   protected function cannotReadInsideEntityRange(): void {
-    $this->get($this->url());
-    $this->assertResponseOk();
-    $this->dontSeeInternalPTR();
+    $this->get($this->url())
+    ->assertSuccessful()
+    ->assertJson(['data'=>[]]);
 
     $this->get($this->url() . "/" . $this->ptr->id);
     $this->assertResponseStatusOneOf([404, 403]);
   }
 
   protected function cannotReadOutsideEntityRange(): void {
-    $this->get($this->url());
-    $this->assertResponseOk();
-    $this->dontSeeExternalPTR();
+    $this->get($this->url())
+    ->assertSuccessful()
+    ->assertJson(['data'=>[]]);
 
     $this->get($this->url() . "/" . $this->externalPtr->id);
     $this->assertResponseStatusOneOf([404, 403]);
   }
 
-  protected function cannotCreateInsideEntityRange(): JsonResponse {
+  protected function cannotCreateInsideEntityRange(): TestResponse {
     $this->mockDns('test_create', '1.1.1.3', 0);
     $resp = $this->tryCreate(['ip' => $this->endEntityRange()]);
     $this->assertResponseStatusOneOf([404, 403]);
     return $resp;
   }
 
-  protected function cannotCreateOutsideEntityRange(): JsonResponse {
+  protected function cannotCreateOutsideEntityRange(): TestResponse {
     $this->mockDns('test_create', '5.5.5.5', 0);
     $resp = $this->tryCreate(['ip' => '5.5.5.5']);
     $this->assertResponseStatusOneOf([404, 403]);
     return $resp;
   }
 
-  protected function cannotUpdateInsideEntityRange(): JsonResponse {
+  protected function cannotUpdateInsideEntityRange(): TestResponse {
     $this->mockDns('test_edit', '1.1.1.1', 0);
     $resp = $this->patch($this->url($this->ptr), [
       'ptr' => 'test_edit',
@@ -295,7 +281,7 @@ class PtrControllerTest extends RdnsTestCase {
     return $resp;
   }
 
-  protected function cannotUpdateOutsideEntityRange(): JsonResponse {
+  protected function cannotUpdateOutsideEntityRange(): TestResponse {
     $this->mockDns('test_edit', '8.8.8.8', 0);
     $resp = $this->patch($this->url($this->externalPtr), [
       'ptr' => 'test_edit',
@@ -304,7 +290,7 @@ class PtrControllerTest extends RdnsTestCase {
     return $resp;
   }
 
-  protected function canUpdateInsideEntityRange(): JsonResponse {
+  protected function canUpdateInsideEntityRange(): TestResponse {
     $this->expectsEvents(Events\PtrPtrUpdated::class);
     $this->mockDns('test_edit', '1.1.1.1', 1);  
     $resp = $this->patch($this->url($this->ptr), [
@@ -316,7 +302,7 @@ class PtrControllerTest extends RdnsTestCase {
     return $resp;
   }
 
-  protected function canUpdateOutsideEntityRange(): JsonResponse {
+  protected function canUpdateOutsideEntityRange(): TestResponse {
     $this->expectsEvents(Events\PtrPtrUpdated::class);
     $this->mockDns('test_edit', '8.8.8.8', 1);
     $resp = $this->patch($this->url($this->externalPtr), [
@@ -328,14 +314,14 @@ class PtrControllerTest extends RdnsTestCase {
     return $resp;
   }
 
-  protected function canDeleteInsideEntityRange(): JsonResponse {
+  protected function canDeleteInsideEntityRange(): TestResponse {
     $this->expectsEvents(Events\PtrDeleted::class);
     $resp = $this->delete($this->url($this->ptr));
     $this->assertResponseOk();
     return $resp;
   }
 
-  protected function canDeleteOutsideEntityRange(): JsonResponse {
+  protected function canDeleteOutsideEntityRange(): TestResponse {
     $this->expectsEvents(Events\PtrDeleted::class);
 
     $resp = $this->delete($this->url($this->externalPtr));
@@ -343,13 +329,13 @@ class PtrControllerTest extends RdnsTestCase {
     return $resp;
   }
 
-  protected function cannotDeleteInsideEntityRange(): JsonResponse {
+  protected function cannotDeleteInsideEntityRange(): TestResponse {
     $resp = $this->delete($this->url($this->ptr));
     $this->assertResponseStatusOneOf([404, 403]);
     return $resp;
   }
 
-  protected function cannotDeleteOutsideEntityRange(): JsonResponse {
+  protected function cannotDeleteOutsideEntityRange(): TestResponse {
     $resp = $this->delete($this->url($this->externalPtr));
     $this->assertResponseStatusOneOf([404, 403]);
     return $resp;

--- a/app/Ptr/PtrControllerTest.php
+++ b/app/Ptr/PtrControllerTest.php
@@ -9,6 +9,28 @@ use App\Server\Port\ServerPortWithEntitiesTestNetwork;
 use Illuminate\Http\JsonResponse;
 use Packages\Rdns\App\RdnsTestCase;
 
+function dns_get_record($ptr, $type = null) {
+    $ips = array(
+        array('host' => 'test_int_ptr_name','ip'=> '1.1.1.1', 'type' => 'A'),
+        array('host' => 'test_create','ip'=> '1.1.1.1', 'type' => 'A'),
+        array('host' => 'test_int_ptr_name','ip'=> '1.1.1.2', 'type' => 'A'),
+        array('host' => 'test_create','ip'=> '1.1.1.2', 'type' => 'A'),
+        array('host' => 'test_int_ptr_name','ip'=> '1.1.1.3', 'type' => 'A'),
+        array('host' => 'test_create','ip'=> '1.1.1.3', 'type' => 'A'),
+        array('host' => 'test_int_ptr_name','ip'=> '5.5.5.5', 'type' => 'A'),
+        array('host' => 'test_create','ip'=> '5.5.5.5', 'type' => 'A'),
+        array('host' => 'test_ext_ptr_name','ip'=> '8.8.8.8', 'type' => 'A'),
+        array('host' => 'test_create','ip'=> '8.8.8.8', 'type' => 'A'),
+    );
+    $array = array();
+    foreach($ips as $ip){      
+      if($ip['host'] == $ptr){
+        array_push($array, $ip);
+      }
+    }
+    return $array;
+}
+
 class PtrControllerTest extends RdnsTestCase {
   const PERMISSIONS = [
     'read' => 'network.entities.read',
@@ -70,8 +92,8 @@ class PtrControllerTest extends RdnsTestCase {
   }
 
   public function tearDown() {
-    $this->externalEntity->delete();
     $this->deletePtrs();
+    $this->externalEntity->delete();
     parent::tearDown();
   }
 
@@ -153,6 +175,14 @@ class PtrControllerTest extends RdnsTestCase {
       $this->get($this->url());
       $this->assertResponseOk();
       $this->assertResponseResultCount(3);
+    });
+  }
+
+  public function testInvalidPtrIpOnCreate(){
+    $this->asAdminWithPermissions(static::PERMISSIONS, function () {
+      $ip = "9.9.9.9";
+      $this->tryCreate(['ip' => $ip]);
+      $this->assertResponseStatus(409);
     });
   }
 

--- a/app/Ptr/PtrUpdateService.php
+++ b/app/Ptr/PtrUpdateService.php
@@ -22,15 +22,22 @@ class PtrUpdateService extends UpdateService {
    */
   private $ptrs;
 
+    /**
+   * @var PtrValidateRdns
+   */
+  private $rdns;
+
   /**
    * PtrUpdateService constructor.
    *
    * @param PtrService    $ptr
    * @param PtrRepository $ptrs
+   * @param PtrValidateRdns $rdns
    */
-  public function boot(PtrService $ptr, PtrRepository $ptrs) {
+  public function boot(PtrService $ptr, PtrRepository $ptrs, PtrValidateRdns $rdns) {
     $this->ptr = $ptr;
     $this->ptrs = $ptrs;
+    $this->rdns = $rdns;
   }
 
   public function afterCreate(Collection $items) {
@@ -60,6 +67,9 @@ class PtrUpdateService extends UpdateService {
   }
 
   protected function beforeCreate(Collection $items) {
+    if(!$this->rdns->validate($this->input('ip'), $this->input('ptr'))){
+      abort(409, "Invalid IP");
+    }
     $this->setIp($items);
   }
 

--- a/app/Ptr/PtrUpdateService.php
+++ b/app/Ptr/PtrUpdateService.php
@@ -53,7 +53,7 @@ class PtrUpdateService extends UpdateService {
   private function setPtr(Collection $items) {
     foreach($items as $ptr){
       if(!$this->ptrValidator->validate($ptr->ip, $this->input('ptr'))){
-        abort(409, "Invalid IP");
+        abort(409, "Invalid IP, IP is not associated with Ptr.");
       }
     }
     $inputs = [

--- a/app/Ptr/PtrUpdateService.php
+++ b/app/Ptr/PtrUpdateService.php
@@ -25,19 +25,19 @@ class PtrUpdateService extends UpdateService {
     /**
    * @var PtrValidateRdns
    */
-  private $rdns;
+  private $ptrValidator;
 
   /**
    * PtrUpdateService constructor.
    *
    * @param PtrService    $ptr
    * @param PtrRepository $ptrs
-   * @param PtrValidateRdns $rdns
+   * @param PtrValidateRdns $ptrValidator
    */
-  public function boot(PtrService $ptr, PtrRepository $ptrs, PtrValidateRdns $rdns) {
+  public function boot(PtrService $ptr, PtrRepository $ptrs, PtrValidateRdns $ptrValidator) {
     $this->ptr = $ptr;
     $this->ptrs = $ptrs;
-    $this->rdns = $rdns;
+    $this->ptrValidator = $ptrValidator;
   }
 
   public function afterCreate(Collection $items) {
@@ -52,7 +52,7 @@ class PtrUpdateService extends UpdateService {
 
   private function setPtr(Collection $items) {
     foreach($items as $ptr){
-      if(!$this->rdns->validate($ptr->ip, $this->input('ptr'))){
+      if(!$this->ptrValidator->validate($ptr->ip, $this->input('ptr'))){
         abort(409, "Invalid IP");
       }
     }

--- a/app/Ptr/PtrUpdateService.php
+++ b/app/Ptr/PtrUpdateService.php
@@ -53,7 +53,7 @@ class PtrUpdateService extends UpdateService {
   private function setPtr(Collection $items) {
     foreach($items as $ptr){
       if(!$this->ptrValidator->validate($ptr->ip, $this->input('ptr'))){
-        abort(409, "Invalid IP, IP is not associated with Ptr.");
+        abort(409, "Invalid PTR, Please ensure that ".$this->input('ptr')." has an A or AAAA DNS record to ".$ptr->ip);
       }
     }
     $inputs = [

--- a/app/Ptr/PtrUpdateService.php
+++ b/app/Ptr/PtrUpdateService.php
@@ -51,6 +51,11 @@ class PtrUpdateService extends UpdateService {
   }
 
   private function setPtr(Collection $items) {
+    foreach($items as $ptr){
+      if(!$this->rdns->validate($ptr->ip, $this->input('ptr'))){
+        abort(409, "Invalid IP");
+      }
+    }
     $inputs = [
       'ptr' => $this->input('ptr') ?: null,
     ];
@@ -67,9 +72,6 @@ class PtrUpdateService extends UpdateService {
   }
 
   protected function beforeCreate(Collection $items) {
-    if(!$this->rdns->validate($this->input('ip'), $this->input('ptr'))){
-      abort(409, "Invalid IP");
-    }
     $this->setIp($items);
   }
 

--- a/app/Ptr/PtrValidateRdns.php
+++ b/app/Ptr/PtrValidateRdns.php
@@ -18,9 +18,12 @@ class PtrValidateRdns {
     $this->dns = $dns;
   }
     /**
+     * @param string $ip
+     * @param string $domain
+     * 
      * @return bool
      */
-    public function validate($ip, $domain) {
+    public function validate( $ip, $domain): bool {
         $answers = $this->dns->getARecords($domain);
         foreach($answers as $record) {
             switch($record['type']) {

--- a/app/Ptr/PtrValidateRdns.php
+++ b/app/Ptr/PtrValidateRdns.php
@@ -20,22 +20,15 @@ class PtrValidateRdns {
     /**
      * @return bool
      */
-    public function validate($input, $domain) {
-        $answers = $this->dns->get($domain);
-        foreach($answers as $x) {
-            if($x['type'] == "A") {
-                $ip = $x['ip'];
-                if($ip == $input){
-                    return true;
-                }
-            }
-            else if($x['type'] == "AAAA") {
-                $ip = $x['ipv6'];
-                if($ip == $input){
-                    return true;
-                }
+    public function validate($ip, $domain) {
+        $answers = $this->dns->getARecords($domain);
+        foreach($answers as $record) {
+            switch($record['type']) {
+               case "A":
+                   return $record['ip'] === $ip;
+               case "AAAA":
+                  return $record['ipv6'] === $ip;
             }
         }
-        return false;
     }
 }

--- a/app/Ptr/PtrValidateRdns.php
+++ b/app/Ptr/PtrValidateRdns.php
@@ -2,15 +2,26 @@
 
 namespace Packages\Rdns\App\Ptr;
 
+use Packages\Rdns\App\Ptr\DnsRecordService;
 
 class PtrValidateRdns {
 
+  /**
+   * @var DnsRecordService
+   */
+  protected $dns;
+
+  /**
+   * @param DnsRecordService $dns
+   */
+  public function __construct(DnsRecordService $dns){
+    $this->dns = $dns;
+  }
     /**
      * @return bool
      */
     public function validate($input, $domain) {
-        $answers = dns_get_record($domain, DNS_A + DNS_AAAA);
-
+        $answers = $this->dns->get($domain);
         foreach($answers as $x) {
             if($x['type'] == "A") {
                 $ip = $x['ip'];

--- a/app/Ptr/PtrValidateRdns.php
+++ b/app/Ptr/PtrValidateRdns.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Packages\Rdns\App\Ptr;
+
+
+class PtrValidateRdns {
+
+    /**
+     * @return bool
+     */
+    public function validate($input, $domain) {
+        $answers = dns_get_record($domain, DNS_A + DNS_AAAA);
+
+        foreach($answers as $x) {
+            if($x['type'] == "A") {
+                $ip = $x['ip'];
+                if($ip == $input){
+                    return true;
+                }
+            }
+            else if($x['type'] == "AAAA") {
+                $ip = $x['ipv6'];
+                if($ip == $input){
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/app/Ptr/PtrValidateRdnsTest.php
+++ b/app/Ptr/PtrValidateRdnsTest.php
@@ -4,63 +4,58 @@ namespace Packages\Rdns\App\Ptr;
 
 use Packages\Rdns\App\RdnsTestCase;
 use Packages\Rdns\App\Ptr\PtrValidateRdns;
-use App\Ip\IpAddressRangeContract;
-use App\Ip\IpAddressV4;
-
-function dns_get_record($domain, $type) {
-    $record = array(
-        array("host"=> "test-ptr","ip"=> '1.1.1.1', "type" => DNS_A),
-        array("host"=> "test-ptr","ip"=> '1.1.1.4', "type" => DNS_MX),
-        array("host"=> "test-ptr","ip"=> '1.1.1.1', "type" => DNS_NS),
-        array("host"=> "test-ptr","ipv6"=> "fe80:1:2:3:a:bad:1dea:dad",'type' => DNS_AAAA)
-    );
-    $array = array();
-    foreach($record as $ip){
-        if($ip["host"] == $domain){
-            if($type == $ip["type"]+DNS_AAAA || $type == $ip["type"]+DNS_A){
-                if($ip["type"] == DNS_A) {
-                    $ip["type"] = "A";
-                }
-                else if($ip["type"] == DNS_AAAA) {
-                    $ip["type"] = "AAAA";
-                }
-                array_push($array,$ip);
-            }
-        }
-    }
-    return $array;
-}
+use Packages\Rdns\App\Ptr\DnsRecordService;
+use Mockery;
 
 class PtrValidateRdnsTest extends RdnsTestCase {
-
-    /**
-     * @var IpAddressRangeContract
-     */
-    private $ipRange;
     
     public function setUp() {
         parent::setUp();
-        $this->ipRange = IpAddressV4::range('1.1.1.1', '1.1.1.4');
+        $this->dns = Mockery::mock(DnsRecordService::class);
+    }
+    /**
+     * @return PtrValidateRdns
+     */
+    private function rdns() {
+      return new PtrValidateRdns($this->dns);
     }
 
     public function testGivenValidIPItShouldReturnTrue(){
-        $ip = $this->ipRange->start();
-        $rDns = app(PtrValidateRdns::class);
-        $result = $rDns->validate($ip, 'test-ptr');
+        $ip = '1.1.1.1';
+        $this->dns
+          ->shouldReceive('get')
+          ->andReturn(
+            array(
+              array("host"=> "test-ptr","ip"=> '1.1.1.1', "type" => "A")              
+            )
+          );
+        $result = $this->rDns()->validate($ip, 'test-ptr');
         $this->assertEquals($result, true);
     }
 
     public function testGivenValidIPV6ItShouldReturnTrue(){
         $ip = "fe80:1:2:3:a:bad:1dea:dad";
-        $rDns = app(PtrValidateRdns::class);
-        $result = $rDns->validate($ip, 'test-ptr');
+        $this->dns
+          ->shouldReceive('get')
+          ->andReturn(
+            array(
+              array("host"=> "test-ptr","ipv6"=> 'fe80:1:2:3:a:bad:1dea:dad', "type" => "AAAA")
+            )
+          );
+        $result = $this->rDns()->validate($ip, 'test-ptr');
         $this->assertEquals($result, true);
     }
 
     public function testGivenInvalidIPItShouldReturnFalse(){
-        $ip = $this->ipRange->end();
-        $rDns = app(PtrValidateRdns::class);
-        $result = $rDns->validate($ip, 'test-ptr');
+        $ip = '9.9.9.9';
+        $this->dns
+          ->shouldReceive('get')
+          ->andReturn(
+            array(
+              array("host"=> "test-ptr","ip"=> '1.1.1.1', "type" => "A")
+            )
+          );
+        $result = $this->rDns()->validate($ip, 'test-ptr');
         $this->assertEquals($result, false);
     }
 }

--- a/app/Ptr/PtrValidateRdnsTest.php
+++ b/app/Ptr/PtrValidateRdnsTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Packages\Rdns\App\Ptr;
+
+use Packages\Rdns\App\RdnsTestCase;
+use Packages\Rdns\App\Ptr\PtrValidateRdns;
+use App\Ip\IpAddressRangeContract;
+use App\Ip\IpAddressV4;
+
+function dns_get_record($domain, $type) {
+    $record = array(
+        array("host"=> "test-ptr","ip"=> '1.1.1.1', "type" => DNS_A),
+        array("host"=> "test-ptr","ip"=> '1.1.1.4', "type" => DNS_MX),
+        array("host"=> "test-ptr","ip"=> '1.1.1.1', "type" => DNS_NS),
+        array("host"=> "test-ptr","ipv6"=> "fe80:1:2:3:a:bad:1dea:dad",'type' => DNS_AAAA)
+    );
+    $array = array();
+    foreach($record as $ip){
+        if($ip["host"] == $domain){
+            if($type == $ip["type"]+DNS_AAAA || $type == $ip["type"]+DNS_A){
+                if($ip["type"] == DNS_A) {
+                    $ip["type"] = "A";
+                }
+                else if($ip["type"] == DNS_AAAA) {
+                    $ip["type"] = "AAAA";
+                }
+                array_push($array,$ip);
+            }
+        }
+    }
+    return $array;
+}
+
+class PtrValidateRdnsTest extends RdnsTestCase {
+
+    /**
+     * @var IpAddressRangeContract
+     */
+    private $ipRange;
+    
+    public function setUp() {
+        parent::setUp();
+        $this->ipRange = IpAddressV4::range('1.1.1.1', '1.1.1.4');
+    }
+
+    public function testGivenValidIPItShouldReturnTrue(){
+        $ip = $this->ipRange->start();
+        $rDns = app(PtrValidateRdns::class);
+        $result = $rDns->validate($ip, 'test-ptr');
+        $this->assertEquals($result, true);
+    }
+
+    public function testGivenValidIPV6ItShouldReturnTrue(){
+        $ip = "fe80:1:2:3:a:bad:1dea:dad";
+        $rDns = app(PtrValidateRdns::class);
+        $result = $rDns->validate($ip, 'test-ptr');
+        $this->assertEquals($result, true);
+    }
+
+    public function testGivenInvalidIPItShouldReturnFalse(){
+        $ip = $this->ipRange->end();
+        $rDns = app(PtrValidateRdns::class);
+        $result = $rDns->validate($ip, 'test-ptr');
+        $this->assertEquals($result, false);
+    }
+}

--- a/app/Ptr/PtrValidateRdnsTest.php
+++ b/app/Ptr/PtrValidateRdnsTest.php
@@ -9,53 +9,58 @@ use Mockery;
 
 class PtrValidateRdnsTest extends RdnsTestCase {
     
-    public function setUp() {
-        parent::setUp();
-        $this->dns = Mockery::mock(DnsRecordService::class);
-    }
-    /**
-     * @return PtrValidateRdns
-     */
-    private function rdns() {
-      return new PtrValidateRdns($this->dns);
-    }
+  public function setUp() {
+      parent::setUp();
+      $this->dns = Mockery::mock(DnsRecordService::class);
+  }
+  /**
+   * @return PtrValidateRdns
+   */
+  private function rdns() {
+    return new PtrValidateRdns($this->dns);
+  }
 
-    public function testGivenValidIPItShouldReturnTrue(){
-        $ip = '1.1.1.1';
-        $this->dns
-          ->shouldReceive('get')
-          ->andReturn(
-            array(
-              array("host"=> "test-ptr","ip"=> '1.1.1.1', "type" => "A")              
-            )
-          );
-        $result = $this->rDns()->validate($ip, 'test-ptr');
-        $this->assertEquals($result, true);
-    }
+  public function testGivenValidIPItShouldReturnTrue(){
+      $ip = '1.1.1.1';
+      $host = 'test-ptr';
+      $this->mockDns($host, "ip", $ip, "A");
+      $result = $this->rDns()->validate($ip, $host);
+      $this->assertEquals($result, true);
+  }
 
-    public function testGivenValidIPV6ItShouldReturnTrue(){
-        $ip = "fe80:1:2:3:a:bad:1dea:dad";
-        $this->dns
-          ->shouldReceive('get')
-          ->andReturn(
-            array(
-              array("host"=> "test-ptr","ipv6"=> 'fe80:1:2:3:a:bad:1dea:dad', "type" => "AAAA")
-            )
-          );
-        $result = $this->rDns()->validate($ip, 'test-ptr');
-        $this->assertEquals($result, true);
-    }
+  public function testGivenValidIPV6ItShouldReturnTrue(){
+      $ip = "fe80:1:2:3:a:bad:1dea:dad";
+      $host = 'test-ptr';
+      $this->mockDns($host, "ipv6", $ip, "AAAA");
+      $result = $this->rDns()->validate($ip, $host);
+      $this->assertEquals($result, true);
+  }
 
-    public function testGivenInvalidIPItShouldReturnFalse(){
-        $ip = '9.9.9.9';
-        $this->dns
-          ->shouldReceive('get')
-          ->andReturn(
-            array(
-              array("host"=> "test-ptr","ip"=> '1.1.1.1', "type" => "A")
-            )
-          );
-        $result = $this->rDns()->validate($ip, 'test-ptr');
-        $this->assertEquals($result, false);
-    }
+  public function testGivenInvalidIPItShouldReturnFalse(){
+      $ip = '9.9.9.9';
+      $host = 'test-ptr';
+      $this->mockDns($host, "ip", '1.1.1.1', "A");
+      $result = $this->rDns()->validate($ip, $host);
+      $this->assertEquals($result, false);
+  }
+
+  public function testGivenInvalidIPV6ItShouldReturnFalse(){
+      $ip = "fe80:111:222:3:a:badsd:1dea:dad";
+      $host = 'test-ptr';
+      $this->mockDns($host, "ipv6", "fe80:1:2:3:a:bad:1dea:dad", "AAAA");
+      $result = $this->rDns()->validate($ip, $host);
+      $this->assertEquals($result, false);
+  }
+
+  private function mockDns($host, $ipType, $ip, $type) {
+    $this->dns
+      ->shouldReceive('getARecords')
+      ->with($host)
+      ->times()
+      ->andReturn(
+        array(
+          array("host"=> $host, $ipType => $ip, "type" => $type)
+        )
+      );
+  }
 }


### PR DESCRIPTION
- added new class to check if created ptrs have a valid ip
- updated update service to use new class
- added tests for new class
- updated controller tests to test for new 409 error if ip is invalid

Manual tests - 
created multiple Prts using ipv4 and ipv6 addresses for php.net, also attempted to create Ptrs for the same php.net domain but using invalid ip addresses